### PR TITLE
feat: add email endpoints

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,10 @@ jobs:
         php-versions: ['7.4', '8.0', '8.1', '8.2']
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
+      - uses: actions/checkout@v4
 
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: composer-${{ hashFiles('composer.lock') }}

--- a/README.md
+++ b/README.md
@@ -363,3 +363,59 @@ Find a template by its ID
 ```php
 $api->templates()->find($templateId);
 ```
+
+### Emails
+
+#### Send email
+
+Send an email to one or more recipients with the specified subject and text / html body.
+
+```php
+$api->emails()->send(
+    Email::create()
+        ->from(EmailRecipient::create('john@example.com', 'John Doe'))
+        ->to(EmailRecipient::create('jane@example.com', 'Jane Doe'))
+        ->subject('Hello World')
+        ->text('Hello World')
+        ->html('<h1>Hello World</h1>')
+);
+```
+
+#### Send email using template
+
+Send an email to one or more recipients using a template.
+
+```php
+$api->emails()->sendUsingTemplate(
+    Email::create()
+        ->from(EmailRecipient::create('john@example.com', 'John Doe'))
+        ->to(EmailRecipient::create('jane@example.com', 'Jane Doe'))
+        ->templateId('ABCDEF12-3456-7890-ABCD-EF1234567890')
+);
+```
+
+#### Get email events
+
+Get a paginated list of email events.
+
+```php
+$api->emails()->getEvents($limit = 20);
+```
+
+### Email templates
+
+#### Get all
+
+Fetch all email templates. This automatically runs through every page and returns an array of all templates.
+
+```php
+$api->emailTemplates()->getAll();
+```
+
+#### Find
+
+Find an email template by its ID
+
+```php
+$api->emailTemplates()->find($templateId);
+```

--- a/src/Endpoints/EmailTemplatesApi.php
+++ b/src/Endpoints/EmailTemplatesApi.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Inmobile\InmobileSDK\Endpoints;
+
+use Inmobile\InmobileSDK\InmobileApi;
+use Inmobile\InmobileSDK\Response;
+use Inmobile\InmobileSDK\Traits\HasPagination;
+
+class EmailTemplatesApi
+{
+    use HasPagination;
+
+    protected InmobileApi $api;
+
+    public function __construct(InmobileApi $api)
+    {
+        $this->api = $api;
+    }
+
+    public function getAll(): array
+    {
+        return $this->fetchAllFrom('/email/templates');
+    }
+
+    public function find(string $id): Response
+    {
+        return $this->api->get('/email/templates/' . $id);
+    }
+}

--- a/src/Endpoints/EmailsApi.php
+++ b/src/Endpoints/EmailsApi.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Inmobile\InmobileSDK\Endpoints;
+
+use Inmobile\InmobileSDK\InmobileApi;
+use Inmobile\InmobileSDK\RequestModels\Email;
+use Inmobile\InmobileSDK\Response;
+use InvalidArgumentException;
+
+class EmailsApi
+{
+    protected InmobileApi $api;
+
+    public function __construct(InmobileApi $api)
+    {
+        $this->api = $api;
+    }
+
+    public function sendUsingTemplate(Email $email): Response
+    {
+        if (empty($email->getSender())) {
+            throw new InvalidArgumentException('Sender is required when sending an email.');
+        }
+
+        if (empty($email->getRecipients())) {
+            throw new InvalidArgumentException('Recipients are required when sending an email.');
+        }
+
+        if (empty($email->getTemplateId())) {
+            throw new InvalidArgumentException('Template ID is required when sending using template.');
+        }
+
+        return $this->api->post('/email/outgoing/sendusingtemplate', $email->toArray());
+    }
+
+    public function send(Email $email): Response
+    {
+        if (empty($email->getSender())) {
+            throw new InvalidArgumentException('Sender is required when sending an email.');
+        }
+
+        if (empty($email->getRecipients())) {
+            throw new InvalidArgumentException('Recipients are required when sending an email.');
+        }
+
+        if (empty($email->getSubject())) {
+            throw new InvalidArgumentException('Subject is required when sending an email.');
+        }
+
+        if (empty($email->getHtml())) {
+            throw new InvalidArgumentException('HTML body is required when sending an email.');
+        }
+
+        if (!empty($email->getTemplateId())) {
+            throw new InvalidArgumentException('Template ID is not allowed when sending an email without a template.');
+        }
+
+        if (!empty($email->getPlaceholders())) {
+            throw new InvalidArgumentException('Placeholders are not allowed when sending an email without a template.');
+        }
+
+        return $this->api->post('/email/outgoing', $email->toArray());
+    }
+
+    public function getEvents(int $limit): Response
+    {
+        return $this->api->get('/email/outgoing/events', ['limit' => $limit]);
+    }
+}

--- a/src/Exceptions/InmobileRequestFailedException.php
+++ b/src/Exceptions/InmobileRequestFailedException.php
@@ -9,10 +9,19 @@ class InmobileRequestFailedException extends Exception
 {
     protected Response $response;
 
+    /** @var string[] */
+    protected array $details = [];
+
     public function __construct(Response $response, ?string $message = null)
     {
-        if ($response->toObject() && property_exists($response->toObject(), 'errorMessage')) {
-            $message = 'The request failed with the following response: ' . $response->toObject()->errorMessage;
+        $responseObject = $response->toObject();
+
+        if ($responseObject && property_exists($responseObject, 'errorMessage')) {
+            $message = 'The request failed with the following response: ' . $responseObject->errorMessage;
+
+            if (property_exists($responseObject, 'details') && is_array($responseObject->details)) {
+                $this->details = $responseObject->details;
+            }
         } elseif (!$message) {
             $message = 'The request failed with an empty response and status code: ' . $response->getStatus();
         }
@@ -30,5 +39,13 @@ class InmobileRequestFailedException extends Exception
     public function getResponse(): Response
     {
         return $this->response;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDetails(): array
+    {
+        return $this->details;
     }
 }

--- a/src/InmobileApi.php
+++ b/src/InmobileApi.php
@@ -3,6 +3,8 @@
 namespace Inmobile\InmobileSDK;
 
 use Inmobile\InmobileSDK\Endpoints\BlacklistApi;
+use Inmobile\InmobileSDK\Endpoints\EmailsApi;
+use Inmobile\InmobileSDK\Endpoints\EmailTemplatesApi;
 use Inmobile\InmobileSDK\Endpoints\GDPRApi;
 use Inmobile\InmobileSDK\Endpoints\ListsApi;
 use Inmobile\InmobileSDK\Endpoints\MessagesApi;
@@ -53,6 +55,16 @@ class InmobileApi
     public function templates(): TemplatesApi
     {
         return new TemplatesApi($this);
+    }
+
+    public function emails(): EmailsApi
+    {
+        return new EmailsApi($this);
+    }
+
+    public function emailTemplates(): EmailTemplatesApi
+    {
+        return new EmailTemplatesApi($this);
     }
 
     public function post($url, ?array $payload = null): Response

--- a/src/RequestModels/Email.php
+++ b/src/RequestModels/Email.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Inmobile\InmobileSDK\RequestModels;
+
+use DateTime;
+
+class Email
+{
+    protected EmailRecipient $sender;
+
+    /** @var EmailRecipient[] */
+    protected array $recipients;
+
+    /** @var EmailRecipient[] */
+    protected array $replyTo = [];
+
+    protected ?string $subject = null;
+
+    protected ?string $html = null;
+
+    protected ?string $text = null;
+
+    protected ?string $templateId = null;
+
+    protected ?string $messageId = null;
+
+    protected ?DateTime $sendTime = null;
+
+    protected ?bool $tracking = null;
+
+    /** @var array<string, string> */
+    protected ?array $placeholders = [];
+
+    public static function create(): self
+    {
+        return new self();
+    }
+
+    public function from(EmailRecipient $sender): self
+    {
+        $this->sender = $sender;
+
+        return $this;
+    }
+
+    public function to(EmailRecipient ...$recipient): self
+    {
+        $this->recipients = $recipient;
+
+        return $this;
+    }
+
+    public function replyTo(EmailRecipient ...$replyTo): self
+    {
+        $this->replyTo = $replyTo;
+
+        return $this;
+    }
+
+    public function subject(?string $subject): self
+    {
+        $this->subject = $subject;
+
+        return $this;
+    }
+
+    public function html(?string $html): self
+    {
+        $this->html = $html;
+
+        return $this;
+    }
+
+    public function text(?string $text): self
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    public function templateId(?string $templateId): self
+    {
+        $this->templateId = $templateId;
+
+        return $this;
+    }
+
+    public function messageId(?string $messageId): self
+    {
+        $this->messageId = $messageId;
+
+        return $this;
+    }
+
+    public function sendAt(DateTime $sendTime): self
+    {
+        $this->sendTime = $sendTime;
+
+        return $this;
+    }
+
+    public function tracking(bool $tracking): self
+    {
+        $this->tracking = $tracking;
+
+        return $this;
+    }
+
+    public function addPlaceholder(string $key, string $value): self
+    {
+        if ($key[0] !== '{' || $key[strlen($key) - 1] !== '}') {
+            $key = sprintf('{%s}', $key);
+        }
+
+        $this->placeholders[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, string> $placeholders
+     */
+    public function placeholders(?array $placeholders): self
+    {
+        foreach ($placeholders as $key => $value) {
+            if (strpos($key, '{') === 0 && strpos($key, '}') === strlen($key) - 1) {
+                continue;
+            }
+
+            $placeholders[sprintf('{%s}', $key)] = $value;
+            unset($placeholders[$key]);
+        }
+
+        $this->placeholders = $placeholders;
+
+        return $this;
+    }
+
+    public function getSender(): EmailRecipient
+    {
+        return $this->sender;
+    }
+
+    public function getRecipients(): array
+    {
+        return $this->recipients;
+    }
+
+    public function getTemplateId(): ?string
+    {
+        return $this->templateId;
+    }
+
+    public function getSubject(): ?string
+    {
+        return $this->subject;
+    }
+
+    public function getHtml(): ?string
+    {
+        return $this->html;
+    }
+
+    public function getPlaceholders(): ?array
+    {
+        return $this->placeholders;
+    }
+
+    public function toArray(): array
+    {
+        $array = [
+            'from' => $this->sender->toArray(),
+            'to' => array_map(fn ($recipient) => $recipient->toArray(), $this->recipients),
+            'replyTo' => array_map(fn ($replyTo) => $replyTo->toArray(), $this->replyTo),
+            'subject' => $this->subject,
+            'html' => $this->html,
+            'text' => $this->text,
+            'templateId' => $this->templateId,
+            'messageId' => $this->messageId,
+            'sendTime' => $this->sendTime ? $this->sendTime->format('Y-m-d\TH:i:s\Z') : null,
+            'tracking' => $this->tracking,
+            'placeholders' => $this->placeholders,
+        ];
+
+        // Remove optional fields that are not set
+        foreach (['subject', 'replyTo', 'html', 'text', 'templateId', 'messageId', 'sendTime', 'tracking', 'placeholders'] as $key) {
+            if (empty($array[$key])) {
+                unset($array[$key]);
+            }
+        }
+
+        return $array;
+    }
+}

--- a/src/RequestModels/EmailRecipient.php
+++ b/src/RequestModels/EmailRecipient.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Inmobile\InmobileSDK\RequestModels;
+
+class EmailRecipient
+{
+    protected string $email;
+    protected string $name;
+
+    public function __construct(string $email, string $name)
+    {
+        $this->email = $email;
+        $this->name = $name;
+    }
+
+    public static function create(string $email, string $name): self
+    {
+        return new self($email, $name);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'emailAddress' => $this->email,
+            'displayName' => $this->name,
+        ];
+    }
+}

--- a/tests/Unit/Endpoints/EmailTemplatesApiTest.php
+++ b/tests/Unit/Endpoints/EmailTemplatesApiTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Inmobile\Tests\Unit\Endpoints;
+
+use Inmobile\InmobileSDK\Endpoints\EmailTemplatesApi;
+use Inmobile\InmobileSDK\InmobileApi;
+use Inmobile\InmobileSDK\Response;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class EmailTemplatesApiTest extends TestCase
+{
+    protected function validTemplateResponse(): string
+    {
+        return <<<JSON
+        {
+            "id": "c7114ec3-8f89-4e26-8048-686585c1da2a",
+            "name": "My template",
+            "text": "My template text {name} {lastname}",
+            "senderName": "My sendername",
+            "encoding": "gsm7",
+            "placeholders": [
+                "{name}",
+                "{lastname}"
+            ],
+            "created": "2001-02-30T14:50:23Z",
+            "lastUpdated": "2001-02-30T14:50:23Z"
+        }
+        JSON;
+    }
+
+    protected function validTemplatesResponse(): string
+    {
+        return <<<JSON
+        {
+            "entries": [
+                {
+                    "id": "c7114ec3-8f89-4e26-8048-686585c1da2a",
+                    "name": "My template",
+                    "text": "My template text {name} {lastname}",
+                    "senderName": "My sendername",
+                    "encoding": "gsm7",
+                    "placeholders": [
+                      "{name}",
+                      "{lastname}"
+                    ],
+                    "created": "2001-02-30T14:50:23Z",
+                    "lastUpdated": "2001-02-30T14:50:23Z"
+                }
+            ],
+            "_links": {
+              "next": "/Feature/Something/cAw2WeS3rdf",
+              "isLastPage": true
+            }
+        }
+        JSON;
+    }
+
+    public function test_get_by_id()
+    {
+        $api = Mockery::mock(InmobileApi::class);
+        $emailTemplatesApi = new EmailTemplatesApi($api);
+
+        $api->shouldReceive('get')
+            ->with('/email/templates/c7114ec3-8f89-4e26-8048-686585c1da2a')
+            ->andReturn(new Response($this->validTemplateResponse(), 200))
+            ->once();
+
+        $response = $emailTemplatesApi->find('c7114ec3-8f89-4e26-8048-686585c1da2a');
+
+        $this->assertInstanceOf(Response::class, $response);
+    }
+
+    public function test_get_all()
+    {
+        $api = Mockery::mock(InmobileApi::class);
+        $emailTemplatesApi = new EmailTemplatesApi($api);
+
+        $api->shouldReceive('get')
+            ->with(
+                '/email/templates',
+                ['pageLimit' => 250]
+            )
+            ->andReturn(new Response($this->validTemplatesResponse(), 200))
+            ->once();
+
+        $response = $emailTemplatesApi->getAll();
+
+        $this->assertIsArray($response);
+    }
+}

--- a/tests/Unit/Endpoints/EmailsApiTest.php
+++ b/tests/Unit/Endpoints/EmailsApiTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Inmobile\Tests\Unit\Endpoints;
+
+use Inmobile\InmobileSDK\Endpoints\EmailsApi;
+use Inmobile\InmobileSDK\InmobileApi;
+use Inmobile\InmobileSDK\RequestModels\Email;
+use Inmobile\InmobileSDK\RequestModels\EmailRecipient;
+use Inmobile\InmobileSDK\Response;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class EmailsApiTest extends MockeryTestCase
+{
+    protected function validEventsResponse(): string {
+        return <<<JSON
+        {
+            "events": [
+                {
+                    "messageId": "id1",
+                    "eventType": 3,
+                    "eventTypeDescription": "Delivered",
+                    "eventTimestamp": "2001-02-30T14:50:23Z"
+                }
+            ]
+        }
+        JSON;
+    }
+
+    public function test_get_events()
+    {
+        $api = Mockery::mock(InmobileApi::class);
+        $emailsApi = new EmailsApi($api);
+
+        $api->shouldReceive('get')
+            ->with(
+                '/email/outgoing/events',
+                ['limit' => 250]
+            )
+            ->andReturn(new Response($this->validEventsResponse(), 200))
+            ->once();
+
+        $response = $emailsApi->getEvents(250);
+
+        $this->assertIsArray($response->toArray()['events']);
+    }
+
+    protected function validEmailResponse(): string
+    {
+        return <<<JSON
+        {
+            "messageId": "8fe266b2-56e9-4b5f-938f-cc5e22530721",
+            "to": [
+                {
+                  "emailAddress": "roy@tomlinson.com",
+                  "displayName": "Roy Tomlinson"
+                }
+            ]
+        }
+        JSON;
+    }
+
+    public function test_send_email()
+    {
+        $api = Mockery::mock(InmobileApi::class);
+        $emailsApi = new EmailsApi($api);
+
+        $email = Email::create()
+            ->subject('Hello World')
+            ->from(EmailRecipient::create('john@example.com', 'John Doe'))
+            ->to(EmailRecipient::create('jane@example.com', 'Jane Doe'))
+            ->html('<h1>Hello World</h1>');
+
+        $api->shouldReceive('post')
+            ->with(
+                '/email/outgoing',
+                Mockery::on(function ($payload) use ($email) {
+                    $this->assertIsArray($payload);
+
+                    $this->assertEquals($email->toArray(), $payload);
+
+                    return true;
+                })
+            )
+            ->andReturn(new Response($this->validEmailResponse(), 200))
+            ->once();
+
+        $response = $emailsApi->send($email);
+
+        $this->assertInstanceOf(Response::class, $response);
+    }
+
+    public function test_send_email_using_template()
+    {
+        $api = Mockery::mock(InmobileApi::class);
+        $emailsApi = new EmailsApi($api);
+
+        $email = Email::create()
+            ->subject('Hello World')
+            ->from(EmailRecipient::create('john@example.com', 'John Doe'))
+            ->to(EmailRecipient::create('jane@example.com', 'Jane Doe'))
+            ->templateId('ecdcb257-c1e9-4b44-8a4e-f05822372d82')
+            ->addPlaceholder('name', 'John Doe');
+
+        $api->shouldReceive('post')
+            ->with(
+                '/email/outgoing/sendusingtemplate',
+                Mockery::on(function ($payload) use ($email) {
+                    $this->assertIsArray($payload);
+
+                    $this->assertEquals($email->toArray(), $payload);
+
+                    return true;
+                })
+            )
+            ->andReturn(new Response($this->validEmailResponse(), 200))
+            ->once();
+
+        $response = $emailsApi->sendUsingTemplate($email);
+
+        $this->assertInstanceOf(Response::class, $response);
+    }
+}

--- a/tests/Unit/RequestModels/EmailRecipientTest.php
+++ b/tests/Unit/RequestModels/EmailRecipientTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Inmobile\Tests\Unit\RequestModels;
+
+use Inmobile\InmobileSDK\RequestModels\EmailRecipient;
+use PHPUnit\Framework\TestCase;
+
+class EmailRecipientTest extends TestCase
+{
+    public function test_can_convert_to_array()
+    {
+        $recipient = EmailRecipient::create('john@example.com', 'John Doe');
+
+        $this->assertEquals(
+            [
+                'emailAddress' => 'john@example.com',
+                'displayName' => 'John Doe',
+            ],
+            $recipient->toArray()
+        );
+    }
+}

--- a/tests/Unit/RequestModels/EmailTest.php
+++ b/tests/Unit/RequestModels/EmailTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Inmobile\Tests\Unit\RequestModels;
+
+use DateTime;
+use Inmobile\InmobileSDK\RequestModels\Email;
+use Inmobile\InmobileSDK\RequestModels\EmailRecipient;
+use PHPUnit\Framework\TestCase;
+
+class EmailTest extends TestCase
+{
+    public function test_can_convert_to_array()
+    {
+        $email = Email::create()
+            ->from(EmailRecipient::create('john@example.com', 'John Doe'))
+            ->to(EmailRecipient::create('jane@example.com', 'Jane Doe'))
+            ->replyTo(EmailRecipient::create('bob@example.com', 'Bob Doe'))
+            ->subject('Hello World')
+            ->html('<h1>Hello World</h1>')
+            ->text('Hello World')
+            ->templateId('ecdcb257-c1e9-4b44-8a4e-f05822372d82')
+            ->messageId('8fe266b2-56e9-4b5f-938f-cc5e22530721')
+            ->sendAt(new DateTime('2021-01-02 03:04:05'))
+            ->tracking(true)
+            ->addPlaceholder('name', 'John Doe');
+
+        $this->assertEquals(
+            [
+                'from' => [
+                    'emailAddress' => 'john@example.com',
+                    'displayName' => 'John Doe',
+                ],
+                'to' => [
+                    [
+                        'emailAddress' => 'jane@example.com',
+                        'displayName' => 'Jane Doe',
+                    ],
+                ],
+                'replyTo' => [
+                    [
+                        'emailAddress' => 'bob@example.com',
+                        'displayName' => 'Bob Doe',
+                    ],
+                ],
+                'subject' => 'Hello World',
+                'html' => '<h1>Hello World</h1>',
+                'text' => 'Hello World',
+                'templateId' => 'ecdcb257-c1e9-4b44-8a4e-f05822372d82',
+                'messageId' => '8fe266b2-56e9-4b5f-938f-cc5e22530721',
+                'sendTime' => '2021-01-02T03:04:05Z',
+                'tracking' => true,
+                'placeholders' => [
+                    '{name}' => 'John Doe',
+                ],
+            ],
+            $email->toArray()
+        );
+    }
+
+    public function test_ignores_unset_optional_fields()
+    {
+        $email = Email::create()
+            ->from(EmailRecipient::create('john@example.com', 'John Doe'))
+            ->to(EmailRecipient::create('jane@example.com', 'Jane Doe'));
+
+        $this->assertEquals(
+            [
+                'from' => [
+                    'emailAddress' => 'john@example.com',
+                    'displayName' => 'John Doe',
+                ],
+                'to' => [
+                    [
+                        'emailAddress' => 'jane@example.com',
+                        'displayName' => 'Jane Doe',
+                    ],
+                ],
+            ],
+            $email->toArray()
+        );
+    }
+}


### PR DESCRIPTION
This PR adds methods for the new email and email template endpoints:

https://api.inmobile.com/docs/index.html?url=/swagger/v1/swagger.json#tag/Email
- Send an email using a template
- Send an email
- Get email events

https://api.inmobile.com/docs/index.html?url=/swagger/v1/swagger.json#tag/Email-Templates
- Get all email templates
- Get email template by id