### PR TITLE
Make nullable parameters explicity nullable for PHP 8.4

### DIFF
--- a/src/CurlClient.php
+++ b/src/CurlClient.php
@@ -9,7 +9,7 @@ class CurlClient
     protected ?string $baseUri = null;
     protected string $apiKey;
 
-    public function __construct(string $apiKey, string $baseUri = null)
+    public function __construct(string $apiKey, ?string $baseUri = null)
     {
         $this->baseUri = $baseUri;
         $this->apiKey = $apiKey;


### PR DESCRIPTION
Implicitly nullable parameter types have been deprecated in PHP 8.4

https://www.php.net/manual/it/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter